### PR TITLE
sa - copy backend CRUD operations for team02 for dining commons menu …

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,131 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+
+/**
+ * This is a REST controller for UCSBDiningCommonsMenuItem
+ */
+
+@Tag(name = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    /**
+     * List all UCSB Dining Commons Menu Items
+     */
+    @Operation(summary = "List all UCSB Dining Commons Menu Items")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allMenuItems() {
+        Iterable<UCSBDiningCommonsMenuItem> items = ucsbDiningCommonsMenuItemRepository.findAll();
+        return items;
+    }
+
+    /**
+     * Get a single UCSB Dining Commons Menu Item by id
+     * 
+     * @param id the id of the menu item
+     * @return a UCSBDiningCommonsMenuItem
+     */
+    @Operation(summary = "Get a single UCSB Dining Commons Menu Item by id")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getById(
+            @Parameter(name = "id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem item = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+        return item;
+    }
+
+    /**
+     * Create a new UCSB Dining Commons Menu Item
+     * 
+     * @param diningcommonscode dining commons code
+     * @param name               name of the menu item
+     * @param station            station where the item is located
+     * @return the saved menu item
+     */
+    @Operation(summary = "Create a new UCSB Dining Commons Menu Item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+            @Parameter(name = "diningcommonscode") @RequestParam String diningcommonscode,
+            @Parameter(name = "name") @RequestParam String name,
+            @Parameter(name = "station") @RequestParam String station
+    ) throws JsonProcessingException {
+
+        UCSBDiningCommonsMenuItem item = new UCSBDiningCommonsMenuItem();
+        item.setDiningCommonsCode(diningcommonscode);
+        item.setName(name);
+        item.setStation(station);
+
+        UCSBDiningCommonsMenuItem savedItem = ucsbDiningCommonsMenuItemRepository.save(item);
+        return savedItem;
+    }
+
+    /**
+     * Delete a UCSB Dining Commons Menu Item
+     * 
+     * @param id the id of the menu item to delete
+     * @return a message indicating the menu item was deleted
+     */
+    @Operation(summary = "Delete a UCSB Dining Commons Menu Item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBDiningCommonsMenuItem(
+            @Parameter(name = "id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem item = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        ucsbDiningCommonsMenuItemRepository.delete(item);
+        return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
+    }
+
+    @Operation(summary = "Update a UCSB Dining Commons Menu Item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
+        @Parameter(name = "id") @RequestParam Long id,
+        @RequestBody UCSBDiningCommonsMenuItem newItem) {
+
+    UCSBDiningCommonsMenuItem item = ucsbDiningCommonsMenuItemRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+   item.setDiningCommonsCode(newItem.getDiningCommonsCode());
+   item.setName(newItem.getName());
+   item.setStation(newItem.getStation());
+
+    ucsbDiningCommonsMenuItemRepository.save(item);
+
+    return item;
+}
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/** 
+ * This is a JPA entity that represents a UCSBDiningMenuItemCommons
+ * 
+ * A UCSBDiningCommons is a dining commons at UCSB
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitem")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+  
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDiningCommonsRepository is a repository for UCSBDiningCommons entities
+ */
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {
+ 
+}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -1,0 +1,60 @@
+{ "databaseChangeLog": [
+  {
+      "changeSet": {
+        "id": "UCSBDiningCommonsMenuItem-1",
+        "author": "saeed-ar",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "UCSBDININGCOMMONSMENUITEM"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "UCSBDININGCOMMONSMENUITEM_PK",
+                      "nullable": false
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DINING_COMMONS_CODE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "STATION",
+                    "type": "VARCHAR(255)"
+                  }
+                }]
+              ,
+              "tableName": "UCSBDININGCOMMONSMENUITEM"
+            }
+          }]
+
+      }
+  }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,277 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+    @MockBean
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Authorization Tests
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+            .andExpect(status().is(403));
+    }
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+            .andExpect(status().is(403));
+    }
+
+    // Database Action Tests
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+        UCSBDiningCommonsMenuItem item = UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("Pizza")
+            .station("Pizza Station")
+            .build();
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(item));
+
+        MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(item);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_menu_items() throws Exception {
+        UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("Pizza")
+            .station("Pizza Station")
+            .build();
+
+        UCSBDiningCommonsMenuItem item2 = UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("de-la-guerra")
+            .name("Tacos")
+            .station("Taco Station")
+            .build();
+
+        ArrayList<UCSBDiningCommonsMenuItem> expectedItems = new ArrayList<>(Arrays.asList(item1, item2));
+
+        when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedItems);
+
+        MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedItems);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+@WithMockUser(roles = { "ADMIN", "USER" })
+@Test
+public void admin_can_post_a_new_menu_item() throws Exception {
+    UCSBDiningCommonsMenuItem newItem = UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("portola")
+            .name("Pasta")
+            .station("Pasta Station")
+            .build();
+
+    when(ucsbDiningCommonsMenuItemRepository.save(any())).thenReturn(newItem);
+
+    MvcResult response = mockMvc.perform(
+            
+            post("/api/ucsbdiningcommonsmenuitem/post")
+                    .param("diningcommonscode", "portola")
+                    .param("name", "Pasta")
+                    .param("station", "Pasta Station")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.diningCommonsCode").value("portola"))
+            .andExpect(jsonPath("$.name").value("Pasta"))
+            .andExpect(jsonPath("$.station").value("Pasta Station"))
+            .andReturn();
+
+            verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(newItem);
+            String expectedJson = mapper.writeValueAsString(newItem);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+}
+
+    
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_menu_item() throws Exception {
+        UCSBDiningCommonsMenuItem item = UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("portola")
+            .name("Pasta")
+            .station("Pasta Station")
+            .build();
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.of(item));
+
+        MvcResult response = mockMvc.perform(
+            delete("/api/ucsbdiningcommonsmenuitem?id=15")
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(any());
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBDiningCommonsMenuItem with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_nonexistent_menu_item_and_gets_right_error_message() throws Exception {
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(
+            delete("/api/ucsbdiningcommonsmenuitem?id=15")
+                .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBDiningCommonsMenuItem with id 15 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_existing_menu_item() throws Exception {
+        UCSBDiningCommonsMenuItem orig = UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("Pizza")
+            .station("Pizza Station")
+            .build();
+
+        UCSBDiningCommonsMenuItem edited = UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("portola")
+            .name("Burger")
+            .station("Grill Station")
+            .build();
+
+        String requestBody = mapper.writeValueAsString(edited);
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L))).thenReturn(Optional.of(orig));
+
+        MvcResult response = mockMvc.perform(
+            put("/api/ucsbdiningcommonsmenuitem?id=67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(orig); // important: save the updated original object
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(requestBody, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_menu_item_that_does_not_exist() throws Exception {
+        UCSBDiningCommonsMenuItem edited = UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("portola")
+            .name("Burger")
+            .station("Grill Station")
+            .build();
+
+        String requestBody = mapper.writeValueAsString(edited);
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(
+            put("/api/ucsbdiningcommonsmenuitem?id=67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBDiningCommonsMenuItem with id 67 not found", json.get("message"));
+    }
+}


### PR DESCRIPTION
Closes #75 
In this PR, we copy over the entity, repository, controller, controller tests, and db migration file (i.e the entire backend CRUD functionallity) for the UCSB Dining commons menu item table, from the prevois project team02. To test you can fire up the application on dokku or local host, login, go to swagger, try each endpoints. 